### PR TITLE
feat: user-service에서 어드민 권한 관리 기능 및 유저수 집계 기능 구현

### DIFF
--- a/user-service/src/main/java/com/happymapleday/user/controller/UserController.java
+++ b/user-service/src/main/java/com/happymapleday/user/controller/UserController.java
@@ -20,6 +20,11 @@ import com.happymapleday.user.dto.PrivacySettingsUpdateRequestDto;
 import com.happymapleday.user.dto.WeeklyResetSettingsUpdateRequestDto;
 import com.happymapleday.user.dto.PasswordChangeRequestDto;
 import com.happymapleday.user.dto.PasswordChangeResponseDto;
+import com.happymapleday.user.dto.AdminUserListResponseDto;
+import com.happymapleday.user.dto.AdminRoleUpdateRequestDto;
+import com.happymapleday.user.dto.AdminRoleUpdateResponseDto;
+import com.happymapleday.user.dto.UserMetricsResponseDto;
+import com.happymapleday.user.dto.AdminVerificationResponseDto;
 import com.happymapleday.user.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +32,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/user")
@@ -223,6 +230,147 @@ public class UserController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ApiResponse.error("주간 초기화 설정 수정 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 일반 권한 유저 목록 조회
+    @GetMapping("/admin/users/normal")
+    public ResponseEntity<ApiResponse<AdminUserListResponseDto>> getNormalUsers() {
+        try {
+            // 어드민 권한 확인
+            if (!userService.isCurrentUserAdmin()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error("어드민 권한이 필요합니다."));
+            }
+            
+            AdminUserListResponseDto response = userService.getNormalUsers();
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("일반 유저 목록 조회 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 어드민 권한 유저 목록 조회
+    @GetMapping("/admin/users/admin")
+    public ResponseEntity<ApiResponse<AdminUserListResponseDto>> getAdminUsers() {
+        try {
+            // 어드민 권한 확인
+            if (!userService.isCurrentUserAdmin()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error("어드민 권한이 필요합니다."));
+            }
+            
+            AdminUserListResponseDto response = userService.getAdminUsers();
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("어드민 유저 목록 조회 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 모든 유저 목록 조회
+    @GetMapping("/admin/users/all")
+    public ResponseEntity<ApiResponse<AdminUserListResponseDto>> getAllUsers() {
+        try {
+            // 어드민 권한 확인
+            if (!userService.isCurrentUserAdmin()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error("어드민 권한이 필요합니다."));
+            }
+            
+            AdminUserListResponseDto response = userService.getAllUsers();
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("전체 유저 목록 조회 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 사용자 권한 변경
+    @PutMapping("/admin/role")
+    public ResponseEntity<ApiResponse<AdminRoleUpdateResponseDto>> updateUserRole(@Valid @RequestBody AdminRoleUpdateRequestDto request) {
+        try {
+            // 어드민 권한 확인
+            if (!userService.isCurrentUserAdmin()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error("어드민 권한이 필요합니다."));
+            }
+            
+            AdminRoleUpdateResponseDto response = userService.updateUserRole(request);
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest()
+                .body(ApiResponse.error(e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("사용자 권한 변경 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 강력한 어드민 권한 검증 (실시간 DB 조회)
+    @GetMapping("/admin/verify")
+    public ResponseEntity<ApiResponse<AdminVerificationResponseDto>> verifyAdminRole() {
+        try {
+            AdminVerificationResponseDto response = userService.verifyCurrentUserAdmin();
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("어드민 권한 확인 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 기존 호환성을 위한 간단한 검증
+    @GetMapping("/admin/verify/simple")
+    public ResponseEntity<ApiResponse<Boolean>> verifyAdminRoleSimple() {
+        try {
+            boolean isAdmin = userService.isCurrentUserAdmin();
+            return ResponseEntity.ok(ApiResponse.success(isAdmin));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("어드민 권한 확인 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 유저 수 집계 (가입자 현황 추이)
+    @GetMapping("/admin/metrics/users")
+    public ResponseEntity<ApiResponse<UserMetricsResponseDto>> getUserMetrics(
+            @RequestParam(defaultValue = "1d") String period,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate) {
+        try {
+            // 어드민 권한 확인
+            if (!userService.isCurrentUserAdmin()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error("어드민 권한이 필요합니다."));
+            }
+            
+            UserMetricsResponseDto response = userService.getUserMetrics(period, startDate, endDate);
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("유저 수 집계 조회 중 오류가 발생했습니다."));
+        }
+    }
+    
+    // 일반 유저 수 집계 (어드민 제외)
+    @GetMapping("/admin/metrics/normal-users")
+    public ResponseEntity<ApiResponse<UserMetricsResponseDto>> getNormalUserMetrics(
+            @RequestParam(defaultValue = "1d") String period,
+            @RequestParam(required = false) LocalDate startDate,
+            @RequestParam(required = false) LocalDate endDate) {
+        try {
+            // 어드민 권한 확인
+            if (!userService.isCurrentUserAdmin()) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(ApiResponse.error("어드민 권한이 필요합니다."));
+            }
+            
+            UserMetricsResponseDto response = userService.getNormalUserMetrics(period, startDate, endDate);
+            return ResponseEntity.ok(ApiResponse.success(response));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error("일반 유저 수 집계 조회 중 오류가 발생했습니다."));
         }
     }
 } 

--- a/user-service/src/main/java/com/happymapleday/user/dto/AdminRoleUpdateRequestDto.java
+++ b/user-service/src/main/java/com/happymapleday/user/dto/AdminRoleUpdateRequestDto.java
@@ -1,0 +1,40 @@
+package com.happymapleday.user.dto;
+
+import com.happymapleday.user.entity.UserRole;
+import jakarta.validation.constraints.NotNull;
+
+public class AdminRoleUpdateRequestDto {
+    
+    @NotNull(message = "사용자 ID는 필수입니다.")
+    private Long userId;
+    
+    @NotNull(message = "사용자 권한은 필수입니다.")
+    private UserRole role;
+    
+    // 기본 생성자
+    public AdminRoleUpdateRequestDto() {}
+    
+    // 생성자
+    public AdminRoleUpdateRequestDto(Long userId, UserRole role) {
+        this.userId = userId;
+        this.role = role;
+    }
+    
+    // Getter 메서드들
+    public Long getUserId() {
+        return userId;
+    }
+    
+    public UserRole getRole() {
+        return role;
+    }
+    
+    // Setter 메서드들
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+    
+    public void setRole(UserRole role) {
+        this.role = role;
+    }
+}

--- a/user-service/src/main/java/com/happymapleday/user/dto/AdminRoleUpdateResponseDto.java
+++ b/user-service/src/main/java/com/happymapleday/user/dto/AdminRoleUpdateResponseDto.java
@@ -1,0 +1,83 @@
+package com.happymapleday.user.dto;
+
+import com.happymapleday.user.entity.UserRole;
+
+public class AdminRoleUpdateResponseDto {
+    
+    private boolean success;
+    private String message;
+    private Long userId;
+    private String mainCharacterName;
+    private UserRole role;
+    
+    // 기본 생성자
+    public AdminRoleUpdateResponseDto() {}
+    
+    // 생성자
+    public AdminRoleUpdateResponseDto(boolean success, String message, Long userId, String mainCharacterName, UserRole role) {
+        this.success = success;
+        this.message = message;
+        this.userId = userId;
+        this.mainCharacterName = mainCharacterName;
+        this.role = role;
+    }
+    
+    // 정적 팩토리 메서드
+    public static AdminRoleUpdateResponseDto success(Long userId, String mainCharacterName, UserRole role) {
+        String message = role.isAdmin() ? 
+            "어드민 권한이 부여되었습니다." : 
+            "일반 사용자 권한으로 변경되었습니다.";
+        return new AdminRoleUpdateResponseDto(true, message, userId, mainCharacterName, role);
+    }
+    
+    public static AdminRoleUpdateResponseDto failure(String message) {
+        return new AdminRoleUpdateResponseDto(false, message, null, null, null);
+    }
+    
+    // Getter 메서드들
+    public boolean isSuccess() {
+        return success;
+    }
+    
+    public String getMessage() {
+        return message;
+    }
+    
+    public Long getUserId() {
+        return userId;
+    }
+    
+    public String getMainCharacterName() {
+        return mainCharacterName;
+    }
+    
+    public UserRole getRole() {
+        return role;
+    }
+    
+    // 편의 메서드
+    public boolean isAdmin() {
+        return role != null && role.isAdmin();
+    }
+    
+    // Setter 메서드들
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+    
+    public void setMessage(String message) {
+        this.message = message;
+    }
+    
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+    
+    public void setMainCharacterName(String mainCharacterName) {
+        this.mainCharacterName = mainCharacterName;
+    }
+    
+    public void setRole(UserRole role) {
+        this.role = role;
+    }
+}

--- a/user-service/src/main/java/com/happymapleday/user/dto/AdminUserListResponseDto.java
+++ b/user-service/src/main/java/com/happymapleday/user/dto/AdminUserListResponseDto.java
@@ -1,0 +1,99 @@
+package com.happymapleday.user.dto;
+
+import com.happymapleday.user.entity.UserRole;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class AdminUserListResponseDto {
+    
+    private List<UserSummary> users;
+    private int totalCount;
+    
+    // 기본 생성자
+    public AdminUserListResponseDto() {}
+    
+    // 생성자
+    public AdminUserListResponseDto(List<UserSummary> users, int totalCount) {
+        this.users = users;
+        this.totalCount = totalCount;
+    }
+    
+    // 정적 팩토리 메서드
+    public static AdminUserListResponseDto of(List<UserSummary> users) {
+        return new AdminUserListResponseDto(users, users.size());
+    }
+    
+    // Getter 메서드들
+    public List<UserSummary> getUsers() {
+        return users;
+    }
+    
+    public int getTotalCount() {
+        return totalCount;
+    }
+    
+    // Setter 메서드들
+    public void setUsers(List<UserSummary> users) {
+        this.users = users;
+    }
+    
+    public void setTotalCount(int totalCount) {
+        this.totalCount = totalCount;
+    }
+    
+    // 내부 클래스
+    public static class UserSummary {
+        private Long id;
+        private String mainCharacterName;
+        private UserRole role;
+        private LocalDateTime createdAt;
+        
+        public UserSummary() {}
+        
+        public UserSummary(Long id, String mainCharacterName, UserRole role, LocalDateTime createdAt) {
+            this.id = id;
+            this.mainCharacterName = mainCharacterName;
+            this.role = role;
+            this.createdAt = createdAt;
+        }
+        
+        // Getter 메서드들
+        public Long getId() {
+            return id;
+        }
+        
+        public String getMainCharacterName() {
+            return mainCharacterName;
+        }
+        
+        public UserRole getRole() {
+            return role;
+        }
+        
+        // 편의 메서드
+        public boolean isAdmin() {
+            return role != null && role.isAdmin();
+        }
+        
+        public LocalDateTime getCreatedAt() {
+            return createdAt;
+        }
+        
+        // Setter 메서드들
+        public void setId(Long id) {
+            this.id = id;
+        }
+        
+        public void setMainCharacterName(String mainCharacterName) {
+            this.mainCharacterName = mainCharacterName;
+        }
+        
+        public void setRole(UserRole role) {
+            this.role = role;
+        }
+        
+        public void setCreatedAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+        }
+    }
+}

--- a/user-service/src/main/java/com/happymapleday/user/dto/AdminVerificationResponseDto.java
+++ b/user-service/src/main/java/com/happymapleday/user/dto/AdminVerificationResponseDto.java
@@ -1,0 +1,54 @@
+package com.happymapleday.user.dto;
+
+public class AdminVerificationResponseDto {
+    
+    private boolean isAdmin;
+    private String adminLevel; // SUPER_ADMIN, ADMIN, MODERATOR 등
+    private long tokenValidUntil; // 토큰 만료 시간
+    
+    // 기본 생성자
+    public AdminVerificationResponseDto() {}
+    
+    // 생성자
+    public AdminVerificationResponseDto(boolean isAdmin, String adminLevel, long tokenValidUntil) {
+        this.isAdmin = isAdmin;
+        this.adminLevel = adminLevel;
+        this.tokenValidUntil = tokenValidUntil;
+    }
+    
+    // 정적 팩토리 메서드
+    public static AdminVerificationResponseDto admin(String level, long validUntil) {
+        return new AdminVerificationResponseDto(true, level, validUntil);
+    }
+    
+    public static AdminVerificationResponseDto notAdmin() {
+        return new AdminVerificationResponseDto(false, null, 0);
+    }
+    
+    // Getter 메서드들
+    public boolean isAdmin() {
+        return isAdmin;
+    }
+    
+    public String getAdminLevel() {
+        return adminLevel;
+    }
+    
+    public long getTokenValidUntil() {
+        return tokenValidUntil;
+    }
+    
+    // Setter 메서드들
+    public void setAdmin(boolean admin) {
+        isAdmin = admin;
+    }
+    
+    public void setAdminLevel(String adminLevel) {
+        this.adminLevel = adminLevel;
+    }
+    
+    public void setTokenValidUntil(long tokenValidUntil) {
+        this.tokenValidUntil = tokenValidUntil;
+    }
+}
+

--- a/user-service/src/main/java/com/happymapleday/user/dto/LoginResponseDto.java
+++ b/user-service/src/main/java/com/happymapleday/user/dto/LoginResponseDto.java
@@ -1,5 +1,7 @@
 package com.happymapleday.user.dto;
 
+import com.happymapleday.user.entity.UserRole;
+
 public class LoginResponseDto {
     
     private String token;          // Access Token
@@ -19,6 +21,12 @@ public class LoginResponseDto {
     // 정적 팩토리 메서드
     public static LoginResponseDto of(String accessToken, String refreshToken, Long userId, String mainCharacterName) {
         return new LoginResponseDto(accessToken, refreshToken, new UserInfo(userId, mainCharacterName));
+    }
+    
+    // JWT에 role이 포함되어 있으므로 클라이언트 라우팅을 위해 role 정보 제공
+    // 실제 권한 검증은 서버에서 JWT 토큰 검증으로 수행
+    public static LoginResponseDto of(String accessToken, String refreshToken, Long userId, String mainCharacterName, UserRole role) {
+        return new LoginResponseDto(accessToken, refreshToken, new UserInfo(userId, mainCharacterName, role));
     }
     
     // Getter 메서드들
@@ -51,12 +59,20 @@ public class LoginResponseDto {
     public static class UserInfo {
         private Long id;
         private String mainCharacterName;
+        private UserRole role;
         
         public UserInfo() {}
         
         public UserInfo(Long id, String mainCharacterName) {
             this.id = id;
             this.mainCharacterName = mainCharacterName;
+            this.role = UserRole.NORMAL; // 기본값
+        }
+        
+        public UserInfo(Long id, String mainCharacterName, UserRole role) {
+            this.id = id;
+            this.mainCharacterName = mainCharacterName;
+            this.role = role;
         }
         
         // Getter 메서드들
@@ -68,6 +84,15 @@ public class LoginResponseDto {
             return mainCharacterName;
         }
         
+        public UserRole getRole() {
+            return role;
+        }
+        
+        // 편의 메서드: 어드민 권한 체크 (클라이언트 라우팅용)
+        public boolean isAdmin() {
+            return role != null && role.isAdmin();
+        }
+        
         // Setter 메서드들
         public void setId(Long id) {
             this.id = id;
@@ -75,6 +100,10 @@ public class LoginResponseDto {
         
         public void setMainCharacterName(String mainCharacterName) {
             this.mainCharacterName = mainCharacterName;
+        }
+        
+        public void setRole(UserRole role) {
+            this.role = role;
         }
     }
 } 

--- a/user-service/src/main/java/com/happymapleday/user/dto/UserMetricsResponseDto.java
+++ b/user-service/src/main/java/com/happymapleday/user/dto/UserMetricsResponseDto.java
@@ -1,0 +1,94 @@
+package com.happymapleday.user.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class UserMetricsResponseDto {
+    
+    private List<UserCountByDate> userCounts;
+    private int totalActiveUsers;
+    private String period;
+    
+    // 기본 생성자
+    public UserMetricsResponseDto() {}
+    
+    // 생성자
+    public UserMetricsResponseDto(List<UserCountByDate> userCounts, int totalActiveUsers, String period) {
+        this.userCounts = userCounts;
+        this.totalActiveUsers = totalActiveUsers;
+        this.period = period;
+    }
+    
+    // 정적 팩토리 메서드
+    public static UserMetricsResponseDto of(List<UserCountByDate> userCounts, int totalActiveUsers, String period) {
+        return new UserMetricsResponseDto(userCounts, totalActiveUsers, period);
+    }
+    
+    // Getter 메서드들
+    public List<UserCountByDate> getUserCounts() {
+        return userCounts;
+    }
+    
+    public int getTotalActiveUsers() {
+        return totalActiveUsers;
+    }
+    
+    public String getPeriod() {
+        return period;
+    }
+    
+    // Setter 메서드들
+    public void setUserCounts(List<UserCountByDate> userCounts) {
+        this.userCounts = userCounts;
+    }
+    
+    public void setTotalActiveUsers(int totalActiveUsers) {
+        this.totalActiveUsers = totalActiveUsers;
+    }
+    
+    public void setPeriod(String period) {
+        this.period = period;
+    }
+    
+    // 내부 클래스
+    public static class UserCountByDate {
+        private LocalDate date;
+        private long cumulativeCount; // 누적 가입자 수
+        private long dailyCount; // 해당 일자 신규 가입자 수
+        
+        public UserCountByDate() {}
+        
+        public UserCountByDate(LocalDate date, long cumulativeCount, long dailyCount) {
+            this.date = date;
+            this.cumulativeCount = cumulativeCount;
+            this.dailyCount = dailyCount;
+        }
+        
+        // Getter 메서드들
+        public LocalDate getDate() {
+            return date;
+        }
+        
+        public long getCumulativeCount() {
+            return cumulativeCount;
+        }
+        
+        public long getDailyCount() {
+            return dailyCount;
+        }
+        
+        // Setter 메서드들
+        public void setDate(LocalDate date) {
+            this.date = date;
+        }
+        
+        public void setCumulativeCount(long cumulativeCount) {
+            this.cumulativeCount = cumulativeCount;
+        }
+        
+        public void setDailyCount(long dailyCount) {
+            this.dailyCount = dailyCount;
+        }
+    }
+}
+

--- a/user-service/src/main/java/com/happymapleday/user/entity/User.java
+++ b/user-service/src/main/java/com/happymapleday/user/entity/User.java
@@ -25,6 +25,10 @@ public class User {
     @Column(name = "nexon_api_key", nullable = false)
     private String nexonApiKey; // 암호화된 API Key
     
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole role = UserRole.NORMAL; // 사용자 권한 역할
+    
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -41,6 +45,7 @@ public class User {
         this.mainCharacterName = mainCharacterName;
         this.password = password;
         this.nexonApiKey = nexonApiKey;
+        this.role = UserRole.NORMAL; // 기본값은 일반 유저
     }
     
     // Getter 메서드들
@@ -68,6 +73,20 @@ public class User {
         return updatedAt;
     }
     
+    public UserRole getRole() {
+        return role;
+    }
+    
+    // 편의 메서드: 어드민 권한 체크
+    public boolean isAdmin() {
+        return role != null && role.isAdmin();
+    }
+    
+    // 편의 메서드: 일반 사용자 체크
+    public boolean isNormal() {
+        return role != null && role.isNormal();
+    }
+    
     // Setter 메서드들 (필요한 경우)
     public void updatePassword(String password) {
         this.password = password;
@@ -79,5 +98,9 @@ public class User {
     
     public void updateMainCharacterName(String mainCharacterName) {
         this.mainCharacterName = mainCharacterName;
+    }
+    
+    public void updateRole(UserRole role) {
+        this.role = role;
     }
 } 

--- a/user-service/src/main/java/com/happymapleday/user/entity/UserRole.java
+++ b/user-service/src/main/java/com/happymapleday/user/entity/UserRole.java
@@ -1,0 +1,31 @@
+package com.happymapleday.user.entity;
+
+/**
+ * 사용자 권한 역할을 정의하는 ENUM
+ * 확장성을 고려하여 추후 MANAGER, MODERATOR 등 추가 가능
+ */
+public enum UserRole {
+    NORMAL("일반 사용자"),
+    ADMIN("관리자");
+    
+    private final String description;
+    
+    UserRole(String description) {
+        this.description = description;
+    }
+    
+    public String getDescription() {
+        return description;
+    }
+    
+    // 어드민 권한 체크 메서드
+    public boolean isAdmin() {
+        return this == ADMIN;
+    }
+    
+    // 일반 사용자 권한 체크 메서드
+    public boolean isNormal() {
+        return this == NORMAL;
+    }
+}
+

--- a/user-service/src/main/java/com/happymapleday/user/repository/UserRepository.java
+++ b/user-service/src/main/java/com/happymapleday/user/repository/UserRepository.java
@@ -1,9 +1,14 @@
 package com.happymapleday.user.repository;
 
 import com.happymapleday.user.entity.User;
+import com.happymapleday.user.entity.UserRole;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +19,66 @@ public interface UserRepository extends JpaRepository<User, Long> {
     
     // 메인 캐릭터명 존재 여부 확인
     boolean existsByMainCharacterName(String mainCharacterName);
+    
+    // 권한별 사용자 조회
+    List<User> findByRoleOrderByCreatedAtDesc(UserRole role);
+    
+    // 일반 사용자 조회 (편의 메서드)
+    default List<User> findNormalUsersOrderByCreatedAtDesc() {
+        return findByRoleOrderByCreatedAtDesc(UserRole.NORMAL);
+    }
+    
+    // 어드민 사용자 조회 (편의 메서드)
+    default List<User> findAdminUsersOrderByCreatedAtDesc() {
+        return findByRoleOrderByCreatedAtDesc(UserRole.ADMIN);
+    }
+    
+    // 모든 사용자 조회 (생성일 기준 내림차순)
+    List<User> findAllByOrderByCreatedAtDesc();
+    
+    // 기간별 가입자 수 집계
+    @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt BETWEEN :startDate AND :endDate")
+    long countUsersByCreatedAtBetween(@Param("startDate") LocalDateTime startDate, 
+                                      @Param("endDate") LocalDateTime endDate);
+    
+    // 전체 활성 사용자 수 (탈퇴하지 않은 사용자)
+    long count();
+    
+    // 특정 날짜까지의 누적 가입자 수
+    @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt <= :endDate")
+    long countUsersByCreatedAtBefore(@Param("endDate") LocalDateTime endDate);
+    
+    // 일별 가입자 수 집계
+    @Query("SELECT DATE(u.createdAt) as date, COUNT(u) as count " +
+           "FROM User u " +
+           "WHERE u.createdAt BETWEEN :startDate AND :endDate " +
+           "GROUP BY DATE(u.createdAt) " +
+           "ORDER BY DATE(u.createdAt)")
+    List<Object[]> getDailyUserRegistrations(@Param("startDate") LocalDateTime startDate, 
+                                           @Param("endDate") LocalDateTime endDate);
+    
+    // 일반 유저만 일별 가입자 수 집계 (어드민 제외)
+    @Query("SELECT DATE(u.createdAt) as date, COUNT(u) as count " +
+           "FROM User u " +
+           "WHERE u.createdAt BETWEEN :startDate AND :endDate " +
+           "AND u.role = :role " +
+           "GROUP BY DATE(u.createdAt) " +
+           "ORDER BY DATE(u.createdAt)")
+    List<Object[]> getDailyUserRegistrationsByRole(@Param("startDate") LocalDateTime startDate, 
+                                                  @Param("endDate") LocalDateTime endDate,
+                                                  @Param("role") UserRole role);
+    
+    // 일반 유저만 기간별 가입자 수 집계 (어드민 제외)
+    @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt BETWEEN :startDate AND :endDate AND u.role = :role")
+    long countUsersByCreatedAtBetweenAndRole(@Param("startDate") LocalDateTime startDate, 
+                                           @Param("endDate") LocalDateTime endDate,
+                                           @Param("role") UserRole role);
+    
+    // 일반 유저만 특정 날짜까지의 누적 가입자 수 (어드민 제외)
+    @Query("SELECT COUNT(u) FROM User u WHERE u.createdAt <= :endDate AND u.role = :role")
+    long countUsersByCreatedAtBeforeAndRole(@Param("endDate") LocalDateTime endDate,
+                                          @Param("role") UserRole role);
+    
+    // 일반 유저 총 수 (어드민 제외)
+    long countByRole(UserRole role);
 } 

--- a/user-service/src/main/java/com/happymapleday/user/service/JwtService.java
+++ b/user-service/src/main/java/com/happymapleday/user/service/JwtService.java
@@ -1,5 +1,6 @@
 package com.happymapleday.user.service;
 
+import com.happymapleday.user.entity.UserRole;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.beans.factory.annotation.Value;
@@ -37,19 +38,25 @@ public class JwtService {
     private final int ACCESS_TOKEN_HOURS = 1;    // Access Token: 1시간
     private final int REFRESH_TOKEN_DAYS = 30;   // Refresh Token: 30일
     
-    // Access Token 생성
-    public String generateAccessToken(Long userId, String mainCharacterName) {
+    // Access Token 생성 (role 정보 포함)
+    public String generateAccessToken(Long userId, String mainCharacterName, UserRole role) {
         Instant now = Instant.now();
         Instant expiration = now.plus(ACCESS_TOKEN_HOURS, ChronoUnit.HOURS);
         
         return Jwts.builder()
                 .subject(userId.toString())
                 .claim("characterName", mainCharacterName)
+                .claim("role", role.name()) // 권한 정보 포함
                 .claim("tokenType", "ACCESS")
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(expiration))
                 .signWith(getSigningKey())
                 .compact();
+    }
+    
+    // 기존 메서드 호환성 유지 (기본값: NORMAL)
+    public String generateAccessToken(Long userId, String mainCharacterName) {
+        return generateAccessToken(userId, mainCharacterName, UserRole.NORMAL);
     }
     
     // Refresh Token 생성
@@ -81,6 +88,22 @@ public class JwtService {
     public String getMainCharacterNameFromToken(String token) {
         Claims claims = validateAndGetClaims(token);
         return claims.get("characterName", String.class);
+    }
+    
+    // JWT 토큰에서 권한 정보 추출
+    public UserRole getRoleFromToken(String token) {
+        Claims claims = validateAndGetClaims(token);
+        String roleString = claims.get("role", String.class);
+        try {
+            return roleString != null ? UserRole.valueOf(roleString) : UserRole.NORMAL;
+        } catch (IllegalArgumentException e) {
+            return UserRole.NORMAL; // 잘못된 값인 경우 기본값
+        }
+    }
+    
+    // JWT 토큰에서 어드민 권한 확인
+    public boolean isAdminFromToken(String token) {
+        return getRoleFromToken(token).isAdmin();
     }
     
     // 토큰 타입 확인 (ACCESS/REFRESH)

--- a/user-service/src/main/java/com/happymapleday/user/service/UserService.java
+++ b/user-service/src/main/java/com/happymapleday/user/service/UserService.java
@@ -19,7 +19,13 @@ import com.happymapleday.user.dto.PrivacySettingsUpdateRequestDto;
 import com.happymapleday.user.dto.WeeklyResetSettingsUpdateRequestDto;
 import com.happymapleday.user.dto.PasswordChangeRequestDto;
 import com.happymapleday.user.dto.PasswordChangeResponseDto;
+import com.happymapleday.user.dto.AdminUserListResponseDto;
+import com.happymapleday.user.dto.AdminRoleUpdateRequestDto;
+import com.happymapleday.user.dto.AdminRoleUpdateResponseDto;
+import com.happymapleday.user.dto.UserMetricsResponseDto;
+import com.happymapleday.user.dto.AdminVerificationResponseDto;
 import com.happymapleday.user.entity.User;
+import com.happymapleday.user.entity.UserRole;
 import com.happymapleday.user.entity.UserSettings;
 import com.happymapleday.user.repository.UserRepository;
 import com.happymapleday.user.repository.UserSettingsRepository;
@@ -32,6 +38,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class UserService {
@@ -72,12 +84,12 @@ public class UserService {
             throw new BadCredentialsException("아이디 또는 비밀번호가 잘못되었습니다.");
         }
         
-        // Access Token과 Refresh Token 생성
-        String accessToken = jwtService.generateAccessToken(user.getId(), user.getMainCharacterName());
+        // Access Token과 Refresh Token 생성 (role 정보 포함)
+        String accessToken = jwtService.generateAccessToken(user.getId(), user.getMainCharacterName(), user.getRole());
         String refreshToken = jwtService.generateRefreshToken(user.getId());
         
-        // 응답 DTO 생성
-        return LoginResponseDto.of(accessToken, refreshToken, user.getId(), user.getMainCharacterName());
+        // 응답 DTO 생성 (role 정보 포함)
+        return LoginResponseDto.of(accessToken, refreshToken, user.getId(), user.getMainCharacterName(), user.getRole());
     }
     
     // 토큰 갱신 처리
@@ -102,8 +114,8 @@ public class UserService {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new BadCredentialsException("사용자를 찾을 수 없습니다."));
             
-            // 새로운 Access Token과 Refresh Token 생성
-            String newAccessToken = jwtService.generateAccessToken(user.getId(), user.getMainCharacterName());
+            // 새로운 Access Token과 Refresh Token 생성 (role 정보 포함)
+            String newAccessToken = jwtService.generateAccessToken(user.getId(), user.getMainCharacterName(), user.getRole());
             String newRefreshToken = jwtService.generateRefreshToken(user.getId());
             
             return RefreshTokenResponseDto.of(newAccessToken, newRefreshToken);
@@ -385,5 +397,242 @@ public class UserService {
         } catch (Exception e) {
             return ApiKeyValidationResponseDto.failure("API Key 검증 처리 중 오류가 발생했습니다.");
         }
+    }
+    
+    // ========== 어드민 관련 메서드들 ==========
+    
+    // 일반 권한 유저 목록 조회
+    public AdminUserListResponseDto getNormalUsers() {
+        List<User> normalUsers = userRepository.findNormalUsersOrderByCreatedAtDesc();
+        
+        List<AdminUserListResponseDto.UserSummary> userSummaries = normalUsers.stream()
+                .map(user -> new AdminUserListResponseDto.UserSummary(
+                        user.getId(),
+                        user.getMainCharacterName(),
+                        user.getRole(),
+                        user.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+        
+        return AdminUserListResponseDto.of(userSummaries);
+    }
+    
+    // 어드민 권한 유저 목록 조회
+    public AdminUserListResponseDto getAdminUsers() {
+        List<User> adminUsers = userRepository.findAdminUsersOrderByCreatedAtDesc();
+        
+        List<AdminUserListResponseDto.UserSummary> userSummaries = adminUsers.stream()
+                .map(user -> new AdminUserListResponseDto.UserSummary(
+                        user.getId(),
+                        user.getMainCharacterName(),
+                        user.getRole(),
+                        user.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+        
+        return AdminUserListResponseDto.of(userSummaries);
+    }
+    
+    // 모든 유저 목록 조회
+    public AdminUserListResponseDto getAllUsers() {
+        List<User> allUsers = userRepository.findAllByOrderByCreatedAtDesc();
+        
+        List<AdminUserListResponseDto.UserSummary> userSummaries = allUsers.stream()
+                .map(user -> new AdminUserListResponseDto.UserSummary(
+                        user.getId(),
+                        user.getMainCharacterName(),
+                        user.getRole(),
+                        user.getCreatedAt()
+                ))
+                .collect(Collectors.toList());
+        
+        return AdminUserListResponseDto.of(userSummaries);
+    }
+    
+    // 사용자 권한 변경
+    @Transactional
+    public AdminRoleUpdateResponseDto updateUserRole(AdminRoleUpdateRequestDto request) {
+        // 사용자 조회
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+        
+        // 권한 업데이트
+        user.updateRole(request.getRole());
+        userRepository.save(user);
+        
+        // 보안상 해당 사용자의 모든 토큰 무효화 (권한 변경 시)
+        secureRefreshTokenService.invalidateAllTokens(user.getId());
+        
+        return AdminRoleUpdateResponseDto.success(
+                user.getId(),
+                user.getMainCharacterName(),
+                user.getRole()
+        );
+    }
+    
+    // 어드민 권한 검증
+    public boolean isUserAdmin(Long userId) {
+        return userRepository.findById(userId)
+                .map(User::isAdmin)
+                .orElse(false);
+    }
+    
+    // 현재 사용자가 어드민인지 확인
+    public boolean isCurrentUserAdmin() {
+        try {
+            Long currentUserId = SecurityUtil.getCurrentUserId();
+            return isUserAdmin(currentUserId);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    // 강화된 어드민 권한 검증 (실시간 DB 조회 + 추가 보안 정보)
+    public AdminVerificationResponseDto verifyCurrentUserAdmin() {
+        try {
+            Long currentUserId = SecurityUtil.getCurrentUserId();
+            
+            // 실시간 DB 조회로 권한 확인
+            User user = userRepository.findById(currentUserId)
+                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+            
+            if (user.isAdmin()) {
+                // 토큰 만료 시간 계산 (예: 1시간 후)
+                long tokenValidUntil = System.currentTimeMillis() + (60 * 60 * 1000);
+                
+                // 어드민 레벨 결정 (향후 확장 가능)
+                String adminLevel = "ADMIN"; // 기본값
+                
+                return AdminVerificationResponseDto.admin(adminLevel, tokenValidUntil);
+            } else {
+                return AdminVerificationResponseDto.notAdmin();
+            }
+            
+        } catch (Exception e) {
+            return AdminVerificationResponseDto.notAdmin();
+        }
+    }
+    
+    // 유저 수 집계 (가입자 현황 추이)
+    public UserMetricsResponseDto getUserMetrics(String period, LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startDateTime;
+        LocalDateTime endDateTime;
+        
+        // 기간별 처리
+        if (startDate != null && endDate != null) {
+            // 직접 검색인 경우
+            startDateTime = startDate.atStartOfDay();
+            endDateTime = endDate.atTime(LocalTime.MAX);
+            period = "custom";
+        } else {
+            // 미리 정의된 기간인 경우
+            LocalDate today = LocalDate.now();
+            endDateTime = today.atTime(LocalTime.MAX);
+            
+            switch (period.toLowerCase()) {
+                case "today":
+                    startDateTime = today.atStartOfDay();
+                    break;
+                case "1w":
+                    startDateTime = today.minusWeeks(1).atStartOfDay();
+                    break;
+                case "1m":
+                    startDateTime = today.minusMonths(1).atStartOfDay();
+                    break;
+                case "3m":
+                    startDateTime = today.minusMonths(3).atStartOfDay();
+                    break;
+                case "6m":
+                    startDateTime = today.minusMonths(6).atStartOfDay();
+                    break;
+                default:
+                    startDateTime = today.minusMonths(1).atStartOfDay();
+                    period = "1m";
+            }
+        }
+        
+        // 일별 가입자 수 조회
+        List<Object[]> dailyRegistrations = userRepository.getDailyUserRegistrations(startDateTime, endDateTime);
+        
+        List<UserMetricsResponseDto.UserCountByDate> userCounts = new ArrayList<>();
+        
+        // 누적 가입자 수 계산을 위한 시작점 조회
+        long baseCount = userRepository.countUsersByCreatedAtBefore(startDateTime);
+        long cumulativeCount = baseCount;
+        
+        for (Object[] row : dailyRegistrations) {
+            LocalDate date = ((java.sql.Date) row[0]).toLocalDate();
+            long dailyCount = ((Number) row[1]).longValue();
+            cumulativeCount += dailyCount;
+            
+            userCounts.add(new UserMetricsResponseDto.UserCountByDate(date, cumulativeCount, dailyCount));
+        }
+        
+        // 전체 활성 사용자 수
+        int totalActiveUsers = (int) userRepository.count();
+        
+        return UserMetricsResponseDto.of(userCounts, totalActiveUsers, period);
+    }
+    
+    // 일반 유저 수 집계 (어드민 제외)
+    public UserMetricsResponseDto getNormalUserMetrics(String period, LocalDate startDate, LocalDate endDate) {
+        LocalDateTime startDateTime;
+        LocalDateTime endDateTime;
+        
+        // 기간별 처리
+        if (startDate != null && endDate != null) {
+            // 직접 검색인 경우
+            startDateTime = startDate.atStartOfDay();
+            endDateTime = endDate.atTime(LocalTime.MAX);
+            period = "custom";
+        } else {
+            // 미리 정의된 기간인 경우
+            LocalDate today = LocalDate.now();
+            endDateTime = today.atTime(LocalTime.MAX);
+            
+            switch (period.toLowerCase()) {
+                case "today":
+                    startDateTime = today.atStartOfDay();
+                    break;
+                case "1w":
+                    startDateTime = today.minusWeeks(1).atStartOfDay();
+                    break;
+                case "1m":
+                    startDateTime = today.minusMonths(1).atStartOfDay();
+                    break;
+                case "3m":
+                    startDateTime = today.minusMonths(3).atStartOfDay();
+                    break;
+                case "6m":
+                    startDateTime = today.minusMonths(6).atStartOfDay();
+                    break;
+                default:
+                    startDateTime = today.minusMonths(1).atStartOfDay();
+                    period = "1m";
+            }
+        }
+        
+        // 일반 유저만 일별 가입자 수 조회 (어드민 제외)
+        List<Object[]> dailyRegistrations = userRepository.getDailyUserRegistrationsByRole(
+                startDateTime, endDateTime, UserRole.NORMAL);
+        
+        List<UserMetricsResponseDto.UserCountByDate> userCounts = new ArrayList<>();
+        
+        // 일반 유저만 누적 가입자 수 계산을 위한 시작점 조회 (어드민 제외)
+        long baseCount = userRepository.countUsersByCreatedAtBeforeAndRole(startDateTime, UserRole.NORMAL);
+        long cumulativeCount = baseCount;
+        
+        for (Object[] row : dailyRegistrations) {
+            LocalDate date = ((java.sql.Date) row[0]).toLocalDate();
+            long dailyCount = ((Number) row[1]).longValue();
+            cumulativeCount += dailyCount;
+            
+            userCounts.add(new UserMetricsResponseDto.UserCountByDate(date, cumulativeCount, dailyCount));
+        }
+        
+        // 전체 일반 유저 수 (어드민 제외)
+        int totalNormalUsers = (int) userRepository.countByRole(UserRole.NORMAL);
+        
+        return UserMetricsResponseDto.of(userCounts, totalNormalUsers, period);
     }
 } 

--- a/user-service/src/test/java/com/happymapleday/user/controller/UserControllerAdminTest.java
+++ b/user-service/src/test/java/com/happymapleday/user/controller/UserControllerAdminTest.java
@@ -1,0 +1,305 @@
+package com.happymapleday.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.happymapleday.user.dto.AdminRoleUpdateRequestDto;
+import com.happymapleday.user.dto.AdminRoleUpdateResponseDto;
+import com.happymapleday.user.dto.AdminUserListResponseDto;
+import com.happymapleday.user.dto.AdminVerificationResponseDto;
+import com.happymapleday.user.entity.UserRole;
+import com.happymapleday.user.service.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(UserController.class)
+class UserControllerAdminTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void testGetNormalUsersSuccess() throws Exception {
+        // given
+        AdminUserListResponseDto.UserSummary userSummary = new AdminUserListResponseDto.UserSummary(
+                1L, "normalUser", UserRole.NORMAL, LocalDateTime.now()
+        );
+        AdminUserListResponseDto response = AdminUserListResponseDto.of(Arrays.asList(userSummary));
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.getNormalUsers()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/users/normal"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.users").isArray())
+                .andExpect(jsonPath("$.data.users[0].role").value("NORMAL"))
+                .andExpect(jsonPath("$.data.users[0].mainCharacterName").value("normalUser"))
+                .andExpect(jsonPath("$.data.totalCount").value(1));
+
+        verify(userService).isCurrentUserAdmin();
+        verify(userService).getNormalUsers();
+    }
+
+    @Test
+    void testGetNormalUsersWithoutAdminPermission() throws Exception {
+        // given
+        when(userService.isCurrentUserAdmin()).thenReturn(false);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/users/normal"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("어드민 권한이 필요합니다."));
+
+        verify(userService).isCurrentUserAdmin();
+        verify(userService, never()).getNormalUsers();
+    }
+
+    @Test
+    void testGetAdminUsersSuccess() throws Exception {
+        // given
+        AdminUserListResponseDto.UserSummary adminSummary = new AdminUserListResponseDto.UserSummary(
+                2L, "adminUser", UserRole.ADMIN, LocalDateTime.now()
+        );
+        AdminUserListResponseDto response = AdminUserListResponseDto.of(Arrays.asList(adminSummary));
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.getAdminUsers()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/users/admin"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.users[0].role").value("ADMIN"))
+                .andExpect(jsonPath("$.data.users[0].mainCharacterName").value("adminUser"));
+
+        verify(userService).getAdminUsers();
+    }
+
+    @Test
+    void testGetAllUsersSuccess() throws Exception {
+        // given
+        AdminUserListResponseDto.UserSummary normalUser = new AdminUserListResponseDto.UserSummary(
+                1L, "normalUser", UserRole.NORMAL, LocalDateTime.now()
+        );
+        AdminUserListResponseDto.UserSummary adminUser = new AdminUserListResponseDto.UserSummary(
+                2L, "adminUser", UserRole.ADMIN, LocalDateTime.now()
+        );
+        AdminUserListResponseDto response = AdminUserListResponseDto.of(Arrays.asList(normalUser, adminUser));
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.getAllUsers()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/users/all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.users").isArray())
+                .andExpect(jsonPath("$.data.users").value(org.hamcrest.Matchers.hasSize(2)))
+                .andExpect(jsonPath("$.data.totalCount").value(2));
+
+        verify(userService).getAllUsers();
+    }
+
+    @Test
+    void testUpdateUserRoleSuccess() throws Exception {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(1L, UserRole.ADMIN);
+        AdminRoleUpdateResponseDto response = AdminRoleUpdateResponseDto.success(1L, "normalUser", UserRole.ADMIN);
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.updateUserRole(any(AdminRoleUpdateRequestDto.class))).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(put("/api/user/admin/role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.success").value(true))
+                .andExpect(jsonPath("$.data.role").value("ADMIN"))
+                .andExpect(jsonPath("$.data.mainCharacterName").value("normalUser"))
+                .andExpect(jsonPath("$.data.message").value("어드민 권한이 부여되었습니다."));
+
+        verify(userService).updateUserRole(any(AdminRoleUpdateRequestDto.class));
+    }
+
+    @Test
+    void testUpdateUserRoleWithoutAdminPermission() throws Exception {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(1L, UserRole.ADMIN);
+
+        when(userService.isCurrentUserAdmin()).thenReturn(false);
+
+        // when & then
+        mockMvc.perform(put("/api/user/admin/role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("어드민 권한이 필요합니다."));
+
+        verify(userService, never()).updateUserRole(any());
+    }
+
+    @Test
+    void testUpdateUserRoleWithInvalidRequest() throws Exception {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(); // userId, role이 null
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+
+        // when & then
+        mockMvc.perform(put("/api/user/admin/role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        verify(userService, never()).updateUserRole(any());
+    }
+
+    @Test
+    void testUpdateUserRoleWithNonExistentUser() throws Exception {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(999L, UserRole.ADMIN);
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.updateUserRole(any(AdminRoleUpdateRequestDto.class)))
+                .thenThrow(new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        // when & then
+        mockMvc.perform(put("/api/user/admin/role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
+    }
+
+    @Test
+    void testVerifyAdminRoleSuccess() throws Exception {
+        // given
+        AdminVerificationResponseDto response = AdminVerificationResponseDto.admin("ADMIN", System.currentTimeMillis() + 3600000);
+
+        when(userService.verifyCurrentUserAdmin()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/verify"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.admin").value(true))
+                .andExpect(jsonPath("$.data.adminLevel").value("ADMIN"))
+                .andExpect(jsonPath("$.data.tokenValidUntil").isNumber());
+
+        verify(userService).verifyCurrentUserAdmin();
+    }
+
+    @Test
+    void testVerifyAdminRoleForNormalUser() throws Exception {
+        // given
+        AdminVerificationResponseDto response = AdminVerificationResponseDto.notAdmin();
+
+        when(userService.verifyCurrentUserAdmin()).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/verify"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.admin").value(false))
+                .andExpect(jsonPath("$.data.adminLevel").isEmpty())
+                .andExpect(jsonPath("$.data.tokenValidUntil").value(0));
+    }
+
+    @Test
+    void testVerifyAdminRoleSimpleSuccess() throws Exception {
+        // given
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/verify/simple"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(true));
+
+        verify(userService).isCurrentUserAdmin();
+    }
+
+    @Test
+    void testVerifyAdminRoleSimpleForNormalUser() throws Exception {
+        // given
+        when(userService.isCurrentUserAdmin()).thenReturn(false);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/verify/simple"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").value(false));
+    }
+
+    @Test
+    void testGetNormalUsersServiceException() throws Exception {
+        // given
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.getNormalUsers()).thenThrow(new RuntimeException("Database error"));
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/users/normal"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("일반 유저 목록 조회 중 오류가 발생했습니다."));
+    }
+
+    @Test
+    void testUpdateUserRoleServiceException() throws Exception {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(1L, UserRole.ADMIN);
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.updateUserRole(any(AdminRoleUpdateRequestDto.class)))
+                .thenThrow(new RuntimeException("Database error"));
+
+        // when & then
+        mockMvc.perform(put("/api/user/admin/role")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("사용자 권한 변경 중 오류가 발생했습니다."));
+    }
+
+    @Test
+    void testEmptyUserListResponse() throws Exception {
+        // given
+        AdminUserListResponseDto emptyResponse = AdminUserListResponseDto.of(Collections.emptyList());
+
+        when(userService.isCurrentUserAdmin()).thenReturn(true);
+        when(userService.getNormalUsers()).thenReturn(emptyResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/user/admin/users/normal"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.users").isArray())
+                .andExpect(jsonPath("$.data.users").isEmpty())
+                .andExpect(jsonPath("$.data.totalCount").value(0));
+    }
+}

--- a/user-service/src/test/java/com/happymapleday/user/entity/UserRoleTest.java
+++ b/user-service/src/test/java/com/happymapleday/user/entity/UserRoleTest.java
@@ -1,0 +1,54 @@
+package com.happymapleday.user.entity;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+
+class UserRoleTest {
+
+    @Test
+    void testUserRoleValues() {
+        // given & when & then
+        assertThat(UserRole.values()).hasSize(2);
+        assertThat(UserRole.values()).containsExactly(UserRole.NORMAL, UserRole.ADMIN);
+    }
+
+    @Test
+    void testUserRoleDescriptions() {
+        // given & when & then
+        assertThat(UserRole.NORMAL.getDescription()).isEqualTo("일반 사용자");
+        assertThat(UserRole.ADMIN.getDescription()).isEqualTo("관리자");
+    }
+
+    @Test
+    void testIsAdminMethod() {
+        // given & when & then
+        assertThat(UserRole.NORMAL.isAdmin()).isFalse();
+        assertThat(UserRole.ADMIN.isAdmin()).isTrue();
+    }
+
+    @Test
+    void testIsNormalMethod() {
+        // given & when & then
+        assertThat(UserRole.NORMAL.isNormal()).isTrue();
+        assertThat(UserRole.ADMIN.isNormal()).isFalse();
+    }
+
+    @Test
+    void testValueOf() {
+        // given & when & then
+        assertThat(UserRole.valueOf("NORMAL")).isEqualTo(UserRole.NORMAL);
+        assertThat(UserRole.valueOf("ADMIN")).isEqualTo(UserRole.ADMIN);
+        
+        // Invalid value should throw exception
+        assertThatThrownBy(() -> UserRole.valueOf("INVALID"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testEnumName() {
+        // given & when & then
+        assertThat(UserRole.NORMAL.name()).isEqualTo("NORMAL");
+        assertThat(UserRole.ADMIN.name()).isEqualTo("ADMIN");
+    }
+}
+

--- a/user-service/src/test/java/com/happymapleday/user/entity/UserTest.java
+++ b/user-service/src/test/java/com/happymapleday/user/entity/UserTest.java
@@ -1,0 +1,136 @@
+package com.happymapleday.user.entity;
+
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+
+class UserTest {
+
+    @Test
+    void testUserCreationWithDefaultRole() {
+        // given
+        String mainCharacterName = "testUser";
+        String password = "password123";
+        String nexonApiKey = "apiKey123";
+
+        // when
+        User user = new User(mainCharacterName, password, nexonApiKey);
+
+        // then
+        assertThat(user.getMainCharacterName()).isEqualTo(mainCharacterName);
+        assertThat(user.getPassword()).isEqualTo(password);
+        assertThat(user.getNexonApiKey()).isEqualTo(nexonApiKey);
+        assertThat(user.getRole()).isEqualTo(UserRole.NORMAL);
+        assertThat(user.isAdmin()).isFalse();
+        assertThat(user.isNormal()).isTrue();
+    }
+
+    @Test
+    void testUpdateRole() {
+        // given
+        User user = new User("testUser", "password", "apiKey");
+        assertThat(user.getRole()).isEqualTo(UserRole.NORMAL);
+
+        // when
+        user.updateRole(UserRole.ADMIN);
+
+        // then
+        assertThat(user.getRole()).isEqualTo(UserRole.ADMIN);
+        assertThat(user.isAdmin()).isTrue();
+        assertThat(user.isNormal()).isFalse();
+    }
+
+    @Test
+    void testUpdateRoleBackToNormal() {
+        // given
+        User user = new User("testUser", "password", "apiKey");
+        user.updateRole(UserRole.ADMIN);
+        assertThat(user.isAdmin()).isTrue();
+
+        // when
+        user.updateRole(UserRole.NORMAL);
+
+        // then
+        assertThat(user.getRole()).isEqualTo(UserRole.NORMAL);
+        assertThat(user.isAdmin()).isFalse();
+        assertThat(user.isNormal()).isTrue();
+    }
+
+    @Test
+    void testIsAdminConvenienceMethod() {
+        // given
+        User normalUser = new User("normalUser", "password", "apiKey");
+        User adminUser = new User("adminUser", "password", "apiKey");
+        adminUser.updateRole(UserRole.ADMIN);
+
+        // when & then
+        assertThat(normalUser.isAdmin()).isFalse();
+        assertThat(adminUser.isAdmin()).isTrue();
+    }
+
+    @Test
+    void testIsNormalConvenienceMethod() {
+        // given
+        User normalUser = new User("normalUser", "password", "apiKey");
+        User adminUser = new User("adminUser", "password", "apiKey");
+        adminUser.updateRole(UserRole.ADMIN);
+
+        // when & then
+        assertThat(normalUser.isNormal()).isTrue();
+        assertThat(adminUser.isNormal()).isFalse();
+    }
+
+    @Test
+    void testUpdatePassword() {
+        // given
+        User user = new User("testUser", "oldPassword", "apiKey");
+        String newPassword = "newPassword123";
+
+        // when
+        user.updatePassword(newPassword);
+
+        // then
+        assertThat(user.getPassword()).isEqualTo(newPassword);
+    }
+
+    @Test
+    void testUpdateNexonApiKey() {
+        // given
+        User user = new User("testUser", "password", "oldApiKey");
+        String newApiKey = "newApiKey123";
+
+        // when
+        user.updateNexonApiKey(newApiKey);
+
+        // then
+        assertThat(user.getNexonApiKey()).isEqualTo(newApiKey);
+    }
+
+    @Test
+    void testUpdateMainCharacterName() {
+        // given
+        User user = new User("oldName", "password", "apiKey");
+        String newName = "newName";
+
+        // when
+        user.updateMainCharacterName(newName);
+
+        // then
+        assertThat(user.getMainCharacterName()).isEqualTo(newName);
+    }
+
+    @Test
+    void testRoleHandlesNullSafely() {
+        // given
+        User user = new User("testUser", "password", "apiKey");
+        
+        // when - 직접 role을 null로 설정 (실제로는 발생하지 않아야 하지만 안전성 테스트)
+        user.updateRole(null);
+
+        // then - null 체크가 있어야 함
+        assertThat(user.getRole()).isNull();
+        // 편의 메서드들이 null을 안전하게 처리하는지 확인
+        assertThat(user.isAdmin()).isFalse();
+        assertThat(user.isNormal()).isFalse();
+    }
+}
+

--- a/user-service/src/test/java/com/happymapleday/user/integration/AdminIntegrationTest.java
+++ b/user-service/src/test/java/com/happymapleday/user/integration/AdminIntegrationTest.java
@@ -1,0 +1,259 @@
+package com.happymapleday.user.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.happymapleday.user.dto.AdminRoleUpdateRequestDto;
+import com.happymapleday.user.dto.LoginRequestDto;
+import com.happymapleday.user.entity.User;
+import com.happymapleday.user.entity.UserRole;
+import com.happymapleday.user.repository.UserRepository;
+import com.happymapleday.user.service.EncryptionService;
+import com.happymapleday.user.service.JwtService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureWebMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureWebMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "jwt.secret=myTestSecretKeyForIntegrationTesting123456789"
+})
+@Transactional
+class AdminIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private EncryptionService encryptionService;
+
+    @Autowired
+    private JwtService jwtService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockMvc mockMvc;
+    private User normalUser;
+    private User adminUser;
+    private String adminToken;
+    private String normalToken;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        
+        // 테스트 데이터 생성
+        createTestUsers();
+        generateTokens();
+    }
+
+    private void createTestUsers() {
+        // 일반 사용자 생성
+        normalUser = new User(
+                "normalUser",
+                passwordEncoder.encode("password123"),
+                encryptionService.encrypt("normalApiKey")
+        );
+        normalUser.updateRole(UserRole.NORMAL);
+        normalUser = userRepository.save(normalUser);
+
+        // 어드민 사용자 생성
+        adminUser = new User(
+                "adminUser",
+                passwordEncoder.encode("password123"),
+                encryptionService.encrypt("adminApiKey")
+        );
+        adminUser.updateRole(UserRole.ADMIN);
+        adminUser = userRepository.save(adminUser);
+    }
+
+    private void generateTokens() {
+        adminToken = jwtService.generateAccessToken(adminUser.getId(), adminUser.getMainCharacterName(), UserRole.ADMIN);
+        normalToken = jwtService.generateAccessToken(normalUser.getId(), normalUser.getMainCharacterName(), UserRole.NORMAL);
+    }
+
+    @Test
+    void testFullAdminWorkflow() throws Exception {
+        // 1. 어드민으로 로그인
+        LoginRequestDto loginRequest = new LoginRequestDto();
+        loginRequest.setMainCharacterName("adminUser");
+        loginRequest.setPassword("password123");
+
+        mockMvc.perform(post("/api/user/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.user.role").value("ADMIN"))
+                .andExpect(jsonPath("$.data.user.mainCharacterName").value("adminUser"));
+
+        // 2. 어드민 권한으로 일반 유저 목록 조회
+        mockMvc.perform(get("/api/user/admin/users/normal")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.users").isArray())
+                .andExpect(jsonPath("$.data.totalCount").value(1));
+
+        // 3. 어드민 권한으로 모든 유저 목록 조회
+        mockMvc.perform(get("/api/user/admin/users/all")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalCount").value(2));
+
+        // 4. 일반 유저를 어드민으로 승격
+        AdminRoleUpdateRequestDto updateRequest = new AdminRoleUpdateRequestDto(normalUser.getId(), UserRole.ADMIN);
+        
+        mockMvc.perform(put("/api/user/admin/role")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.success").value(true))
+                .andExpect(jsonPath("$.data.role").value("ADMIN"));
+
+        // 5. 어드민 유저 목록 조회 (2명이 되어야 함)
+        mockMvc.perform(get("/api/user/admin/users/admin")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.totalCount").value(2));
+    }
+
+    @Test
+    void testNormalUserCannotAccessAdminEndpoints() throws Exception {
+        // 일반 유저 토큰으로 어드민 API 접근 시도
+        mockMvc.perform(get("/api/user/admin/users/all")
+                        .header("Authorization", "Bearer " + normalToken))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("어드민 권한이 필요합니다."));
+
+        // 권한 변경 시도
+        AdminRoleUpdateRequestDto updateRequest = new AdminRoleUpdateRequestDto(normalUser.getId(), UserRole.ADMIN);
+        
+        mockMvc.perform(put("/api/user/admin/role")
+                        .header("Authorization", "Bearer " + normalToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false));
+    }
+
+    @Test
+    void testAdminVerificationEndpoint() throws Exception {
+        // 어드민 사용자 검증
+        mockMvc.perform(get("/api/user/admin/verify")
+                        .header("Authorization", "Bearer " + adminToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.admin").value(true))
+                .andExpect(jsonPath("$.data.adminLevel").value("ADMIN"));
+
+        // 일반 사용자 검증
+        mockMvc.perform(get("/api/user/admin/verify")
+                        .header("Authorization", "Bearer " + normalToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.admin").value(false));
+    }
+
+    @Test
+    void testJwtTokenContainsRoleInformation() throws Exception {
+        // JWT 토큰에서 role 정보 추출 테스트
+        UserRole adminRole = jwtService.getRoleFromToken(adminToken);
+        UserRole normalRole = jwtService.getRoleFromToken(normalToken);
+
+        assert adminRole == UserRole.ADMIN;
+        assert normalRole == UserRole.NORMAL;
+        assert jwtService.isAdminFromToken(adminToken);
+        assert !jwtService.isAdminFromToken(normalToken);
+    }
+
+    @Test
+    void testRoleDowngrade() throws Exception {
+        // 어드민을 일반 사용자로 강등
+        AdminRoleUpdateRequestDto downgradeRequest = new AdminRoleUpdateRequestDto(adminUser.getId(), UserRole.NORMAL);
+        
+        mockMvc.perform(put("/api/user/admin/role")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(downgradeRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.role").value("NORMAL"))
+                .andExpect(jsonPath("$.data.message").value("일반 사용자 권한으로 변경되었습니다."));
+
+        // 강등 후 어드민 API 접근 불가 확인 (새로운 토큰 필요)
+        User updatedAdminUser = userRepository.findById(adminUser.getId()).orElseThrow();
+        String newToken = jwtService.generateAccessToken(updatedAdminUser.getId(), updatedAdminUser.getMainCharacterName(), updatedAdminUser.getRole());
+        
+        mockMvc.perform(get("/api/user/admin/users/all")
+                        .header("Authorization", "Bearer " + newToken))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void testInvalidTokenAccess() throws Exception {
+        // 잘못된 토큰으로 접근
+        mockMvc.perform(get("/api/user/admin/users/all")
+                        .header("Authorization", "Bearer invalid.token.here"))
+                .andExpect(status().isUnauthorized());
+
+        // 토큰 없이 접근
+        mockMvc.perform(get("/api/user/admin/users/all"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testNormalUserLogin() throws Exception {
+        // 일반 사용자 로그인
+        LoginRequestDto loginRequest = new LoginRequestDto();
+        loginRequest.setMainCharacterName("normalUser");
+        loginRequest.setPassword("password123");
+
+        mockMvc.perform(post("/api/user/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.user.role").value("NORMAL"))
+                .andExpect(jsonPath("$.data.user.mainCharacterName").value("normalUser"));
+    }
+
+    @Test
+    void testUpdateNonExistentUser() throws Exception {
+        // 존재하지 않는 사용자 권한 변경 시도
+        AdminRoleUpdateRequestDto updateRequest = new AdminRoleUpdateRequestDto(999L, UserRole.ADMIN);
+        
+        mockMvc.perform(put("/api/user/admin/role")
+                        .header("Authorization", "Bearer " + adminToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 사용자입니다."));
+    }
+}

--- a/user-service/src/test/java/com/happymapleday/user/service/JwtServiceTest.java
+++ b/user-service/src/test/java/com/happymapleday/user/service/JwtServiceTest.java
@@ -1,0 +1,246 @@
+package com.happymapleday.user.service;
+
+import com.happymapleday.user.entity.UserRole;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.*;
+
+class JwtServiceTest {
+
+    private JwtService jwtService;
+    private final String testSecretKey = "mySecretKeyForTestingPurposes123456789";
+
+    @BeforeEach
+    void setUp() {
+        jwtService = new JwtService();
+        ReflectionTestUtils.setField(jwtService, "secretKey", testSecretKey);
+    }
+
+    @Test
+    void testGenerateAccessTokenWithRole() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        UserRole role = UserRole.ADMIN;
+
+        // when
+        String token = jwtService.generateAccessToken(userId, mainCharacterName, role);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token).isNotEmpty();
+
+        // JWT 구조 확인 (header.payload.signature)
+        String[] tokenParts = token.split("\\.");
+        assertThat(tokenParts).hasSize(3);
+    }
+
+    @Test
+    void testGenerateAccessTokenWithDefaultRole() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+
+        // when
+        String token = jwtService.generateAccessToken(userId, mainCharacterName);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token).isNotEmpty();
+
+        // 기본 권한이 NORMAL인지 확인
+        UserRole extractedRole = jwtService.getRoleFromToken(token);
+        assertThat(extractedRole).isEqualTo(UserRole.NORMAL);
+    }
+
+    @Test
+    void testExtractUserIdFromToken() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        UserRole role = UserRole.ADMIN;
+        String token = jwtService.generateAccessToken(userId, mainCharacterName, role);
+
+        // when
+        Long extractedUserId = jwtService.getUserIdFromToken(token);
+
+        // then
+        assertThat(extractedUserId).isEqualTo(userId);
+    }
+
+    @Test
+    void testExtractMainCharacterNameFromToken() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        UserRole role = UserRole.ADMIN;
+        String token = jwtService.generateAccessToken(userId, mainCharacterName, role);
+
+        // when
+        String extractedName = jwtService.getMainCharacterNameFromToken(token);
+
+        // then
+        assertThat(extractedName).isEqualTo(mainCharacterName);
+    }
+
+    @Test
+    void testExtractRoleFromToken() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        UserRole role = UserRole.ADMIN;
+        String token = jwtService.generateAccessToken(userId, mainCharacterName, role);
+
+        // when
+        UserRole extractedRole = jwtService.getRoleFromToken(token);
+
+        // then
+        assertThat(extractedRole).isEqualTo(role);
+    }
+
+    @Test
+    void testExtractRoleFromTokenWithNormalRole() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        UserRole role = UserRole.NORMAL;
+        String token = jwtService.generateAccessToken(userId, mainCharacterName, role);
+
+        // when
+        UserRole extractedRole = jwtService.getRoleFromToken(token);
+
+        // then
+        assertThat(extractedRole).isEqualTo(UserRole.NORMAL);
+    }
+
+    @Test
+    void testIsAdminFromToken() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        
+        String adminToken = jwtService.generateAccessToken(userId, mainCharacterName, UserRole.ADMIN);
+        String normalToken = jwtService.generateAccessToken(userId, mainCharacterName, UserRole.NORMAL);
+
+        // when & then
+        assertThat(jwtService.isAdminFromToken(adminToken)).isTrue();
+        assertThat(jwtService.isAdminFromToken(normalToken)).isFalse();
+    }
+
+    @Test
+    void testTokenValidation() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        UserRole role = UserRole.ADMIN;
+        String token = jwtService.generateAccessToken(userId, mainCharacterName, role);
+
+        // when & then
+        assertThat(jwtService.isTokenValid(token)).isTrue();
+    }
+
+    @Test
+    void testInvalidTokenValidation() {
+        // given
+        String invalidToken = "invalid.token.here";
+
+        // when & then
+        assertThat(jwtService.isTokenValid(invalidToken)).isFalse();
+    }
+
+    @Test
+    void testGenerateRefreshToken() {
+        // given
+        Long userId = 123L;
+
+        // when
+        String refreshToken = jwtService.generateRefreshToken(userId);
+
+        // then
+        assertThat(refreshToken).isNotNull();
+        assertThat(refreshToken).isNotEmpty();
+        
+        // Refresh Token 타입 확인
+        String tokenType = jwtService.getTokenType(refreshToken);
+        assertThat(tokenType).isEqualTo("REFRESH");
+        
+        // 사용자 ID 추출 확인
+        Long extractedUserId = jwtService.getUserIdFromToken(refreshToken);
+        assertThat(extractedUserId).isEqualTo(userId);
+    }
+
+    @Test
+    void testAccessTokenType() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        UserRole role = UserRole.ADMIN;
+        String token = jwtService.generateAccessToken(userId, mainCharacterName, role);
+
+        // when
+        String tokenType = jwtService.getTokenType(token);
+
+        // then
+        assertThat(tokenType).isEqualTo("ACCESS");
+    }
+
+    @Test
+    void testIsRefreshToken() {
+        // given
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        
+        String accessToken = jwtService.generateAccessToken(userId, mainCharacterName, UserRole.ADMIN);
+        String refreshToken = jwtService.generateRefreshToken(userId);
+
+        // when & then
+        assertThat(jwtService.isRefreshToken(accessToken)).isFalse();
+        assertThat(jwtService.isRefreshToken(refreshToken)).isTrue();
+    }
+
+    @Test
+    void testGetRoleFromTokenWithInvalidRole() {
+        // given - 수동으로 잘못된 role이 포함된 토큰 생성
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        
+        // 잘못된 role 값으로 토큰 생성
+        String tokenWithInvalidRole = Jwts.builder()
+                .subject(userId.toString())
+                .claim("characterName", mainCharacterName)
+                .claim("role", "INVALID_ROLE")
+                .claim("tokenType", "ACCESS")
+                .signWith(Keys.hmacShaKeyFor(testSecretKey.getBytes()))
+                .compact();
+
+        // when
+        UserRole extractedRole = jwtService.getRoleFromToken(tokenWithInvalidRole);
+
+        // then - 잘못된 값인 경우 기본값(NORMAL) 반환
+        assertThat(extractedRole).isEqualTo(UserRole.NORMAL);
+    }
+
+    @Test
+    void testGetRoleFromTokenWithNullRole() {
+        // given - role 클레임이 없는 토큰 생성
+        Long userId = 123L;
+        String mainCharacterName = "testUser";
+        
+        String tokenWithoutRole = Jwts.builder()
+                .subject(userId.toString())
+                .claim("characterName", mainCharacterName)
+                .claim("tokenType", "ACCESS")
+                .signWith(Keys.hmacShaKeyFor(testSecretKey.getBytes()))
+                .compact();
+
+        // when
+        UserRole extractedRole = jwtService.getRoleFromToken(tokenWithoutRole);
+
+        // then - role이 없는 경우 기본값(NORMAL) 반환
+        assertThat(extractedRole).isEqualTo(UserRole.NORMAL);
+    }
+}

--- a/user-service/src/test/java/com/happymapleday/user/service/UserServiceAdminTest.java
+++ b/user-service/src/test/java/com/happymapleday/user/service/UserServiceAdminTest.java
@@ -1,0 +1,339 @@
+package com.happymapleday.user.service;
+
+import com.happymapleday.user.dto.AdminRoleUpdateRequestDto;
+import com.happymapleday.user.dto.AdminRoleUpdateResponseDto;
+import com.happymapleday.user.dto.AdminUserListResponseDto;
+import com.happymapleday.user.dto.AdminVerificationResponseDto;
+import com.happymapleday.user.dto.LoginRequestDto;
+import com.happymapleday.user.dto.LoginResponseDto;
+import com.happymapleday.user.entity.User;
+import com.happymapleday.user.entity.UserRole;
+import com.happymapleday.user.repository.UserRepository;
+import com.happymapleday.user.repository.UserSettingsRepository;
+import com.happymapleday.user.util.SecurityUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceAdminTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserSettingsRepository userSettingsRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private EncryptionService encryptionService;
+
+    @Mock
+    private JwtService jwtService;
+
+    @Mock
+    private SecureRefreshTokenService secureRefreshTokenService;
+
+    @Mock
+    private NexonApiService nexonApiService;
+
+    @InjectMocks
+    private UserService userService;
+
+    private User normalUser;
+    private User adminUser;
+
+    @BeforeEach
+    void setUp() {
+        normalUser = new User("normalUser", "password", "apiKey");
+        normalUser.updateRole(UserRole.NORMAL);
+        
+        adminUser = new User("adminUser", "password", "apiKey");
+        adminUser.updateRole(UserRole.ADMIN);
+        
+        // ID 설정을 위해 리플렉션 사용
+        setUserId(normalUser, 1L);
+        setUserId(adminUser, 2L);
+    }
+
+    private void setUserId(User user, Long id) {
+        try {
+            var idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(user, id);
+        } catch (Exception e) {
+            // 테스트용이므로 예외 무시
+        }
+    }
+
+    @Test
+    void testLoginWithAdminRole() {
+        // given
+        LoginRequestDto loginRequest = new LoginRequestDto();
+        loginRequest.setMainCharacterName("adminUser");
+        loginRequest.setPassword("password");
+
+        when(userRepository.findByMainCharacterName("adminUser")).thenReturn(Optional.of(adminUser));
+        when(passwordEncoder.matches("password", "password")).thenReturn(true);
+        when(jwtService.generateAccessToken(2L, "adminUser", UserRole.ADMIN)).thenReturn("access-token");
+        when(jwtService.generateRefreshToken(2L)).thenReturn("refresh-token");
+
+        // when
+        LoginResponseDto response = userService.login(loginRequest);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getToken()).isEqualTo("access-token");
+        assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+        assertThat(response.getUser().getRole()).isEqualTo(UserRole.ADMIN);
+        assertThat(response.getUser().isAdmin()).isTrue();
+
+        verify(jwtService).generateAccessToken(2L, "adminUser", UserRole.ADMIN);
+    }
+
+    @Test
+    void testLoginWithNormalRole() {
+        // given
+        LoginRequestDto loginRequest = new LoginRequestDto();
+        loginRequest.setMainCharacterName("normalUser");
+        loginRequest.setPassword("password");
+
+        when(userRepository.findByMainCharacterName("normalUser")).thenReturn(Optional.of(normalUser));
+        when(passwordEncoder.matches("password", "password")).thenReturn(true);
+        when(jwtService.generateAccessToken(1L, "normalUser", UserRole.NORMAL)).thenReturn("access-token");
+        when(jwtService.generateRefreshToken(1L)).thenReturn("refresh-token");
+
+        // when
+        LoginResponseDto response = userService.login(loginRequest);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUser().getRole()).isEqualTo(UserRole.NORMAL);
+        assertThat(response.getUser().isAdmin()).isFalse();
+
+        verify(jwtService).generateAccessToken(1L, "normalUser", UserRole.NORMAL);
+    }
+
+    @Test
+    void testGetNormalUsers() {
+        // given
+        List<User> normalUsers = Arrays.asList(normalUser);
+        when(userRepository.findNormalUsersOrderByCreatedAtDesc()).thenReturn(normalUsers);
+
+        // when
+        AdminUserListResponseDto response = userService.getNormalUsers();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUsers()).hasSize(1);
+        assertThat(response.getUsers().get(0).getRole()).isEqualTo(UserRole.NORMAL);
+        assertThat(response.getUsers().get(0).getMainCharacterName()).isEqualTo("normalUser");
+        assertThat(response.getTotalCount()).isEqualTo(1);
+    }
+
+    @Test
+    void testGetAdminUsers() {
+        // given
+        List<User> adminUsers = Arrays.asList(adminUser);
+        when(userRepository.findAdminUsersOrderByCreatedAtDesc()).thenReturn(adminUsers);
+
+        // when
+        AdminUserListResponseDto response = userService.getAdminUsers();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUsers()).hasSize(1);
+        assertThat(response.getUsers().get(0).getRole()).isEqualTo(UserRole.ADMIN);
+        assertThat(response.getUsers().get(0).getMainCharacterName()).isEqualTo("adminUser");
+        assertThat(response.getUsers().get(0).isAdmin()).isTrue();
+    }
+
+    @Test
+    void testGetAllUsers() {
+        // given
+        List<User> allUsers = Arrays.asList(normalUser, adminUser);
+        when(userRepository.findAllByOrderByCreatedAtDesc()).thenReturn(allUsers);
+
+        // when
+        AdminUserListResponseDto response = userService.getAllUsers();
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.getUsers()).hasSize(2);
+        assertThat(response.getTotalCount()).isEqualTo(2);
+    }
+
+    @Test
+    void testUpdateUserRoleToAdmin() {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(1L, UserRole.ADMIN);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+        when(userRepository.save(any(User.class))).thenReturn(normalUser);
+
+        // when
+        AdminRoleUpdateResponseDto response = userService.updateUserRole(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getRole()).isEqualTo(UserRole.ADMIN);
+        assertThat(response.getMessage()).contains("어드민 권한이 부여되었습니다");
+        
+        verify(secureRefreshTokenService).invalidateAllTokens(1L);
+        verify(userRepository).save(normalUser);
+        assertThat(normalUser.getRole()).isEqualTo(UserRole.ADMIN);
+    }
+
+    @Test
+    void testUpdateUserRoleToNormal() {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(2L, UserRole.NORMAL);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(adminUser));
+        when(userRepository.save(any(User.class))).thenReturn(adminUser);
+
+        // when
+        AdminRoleUpdateResponseDto response = userService.updateUserRole(request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.isSuccess()).isTrue();
+        assertThat(response.getRole()).isEqualTo(UserRole.NORMAL);
+        assertThat(response.getMessage()).contains("일반 사용자 권한으로 변경되었습니다");
+        
+        verify(secureRefreshTokenService).invalidateAllTokens(2L);
+        assertThat(adminUser.getRole()).isEqualTo(UserRole.NORMAL);
+    }
+
+    @Test
+    void testUpdateUserRoleWithNonExistentUser() {
+        // given
+        AdminRoleUpdateRequestDto request = new AdminRoleUpdateRequestDto(999L, UserRole.ADMIN);
+        when(userRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUserRole(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 사용자입니다.");
+    }
+
+    @Test
+    void testIsUserAdmin() {
+        // given
+        when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(adminUser));
+
+        // when & then
+        assertThat(userService.isUserAdmin(1L)).isFalse();
+        assertThat(userService.isUserAdmin(2L)).isTrue();
+        assertThat(userService.isUserAdmin(999L)).isFalse(); // 존재하지 않는 사용자
+    }
+
+    @Test
+    void testIsCurrentUserAdmin() {
+        // given
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(2L);
+            when(userRepository.findById(2L)).thenReturn(Optional.of(adminUser));
+
+            // when
+            boolean isAdmin = userService.isCurrentUserAdmin();
+
+            // then
+            assertThat(isAdmin).isTrue();
+        }
+    }
+
+    @Test
+    void testIsCurrentUserAdminWithNormalUser() {
+        // given
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+
+            // when
+            boolean isAdmin = userService.isCurrentUserAdmin();
+
+            // then
+            assertThat(isAdmin).isFalse();
+        }
+    }
+
+    @Test
+    void testIsCurrentUserAdminWithException() {
+        // given
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenThrow(new RuntimeException("No authentication"));
+
+            // when
+            boolean isAdmin = userService.isCurrentUserAdmin();
+
+            // then
+            assertThat(isAdmin).isFalse();
+        }
+    }
+
+    @Test
+    void testVerifyCurrentUserAdmin() {
+        // given
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(2L);
+            when(userRepository.findById(2L)).thenReturn(Optional.of(adminUser));
+
+            // when
+            AdminVerificationResponseDto response = userService.verifyCurrentUserAdmin();
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isAdmin()).isTrue();
+            assertThat(response.getAdminLevel()).isEqualTo("ADMIN");
+            assertThat(response.getTokenValidUntil()).isGreaterThan(System.currentTimeMillis());
+        }
+    }
+
+    @Test
+    void testVerifyCurrentUserAdminWithNormalUser() {
+        // given
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenReturn(1L);
+            when(userRepository.findById(1L)).thenReturn(Optional.of(normalUser));
+
+            // when
+            AdminVerificationResponseDto response = userService.verifyCurrentUserAdmin();
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isAdmin()).isFalse();
+            assertThat(response.getAdminLevel()).isNull();
+            assertThat(response.getTokenValidUntil()).isEqualTo(0);
+        }
+    }
+
+    @Test
+    void testVerifyCurrentUserAdminWithException() {
+        // given
+        try (MockedStatic<SecurityUtil> securityUtilMock = mockStatic(SecurityUtil.class)) {
+            securityUtilMock.when(SecurityUtil::getCurrentUserId).thenThrow(new RuntimeException("No authentication"));
+
+            // when
+            AdminVerificationResponseDto response = userService.verifyCurrentUserAdmin();
+
+            // then
+            assertThat(response).isNotNull();
+            assertThat(response.isAdmin()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
- 사용자 권한을 UserRole enum으로 설정
- JWT 토큰에 role 정보 포함하여 보안 강화
- 어드민 사용자 관리 API 추가
- 실시간 권한 검증 API 추가
- 사용자 집계 API 추가