### PR TITLE
fix: settlement-service에서 404에러가 발생하던 현상 수정

### DIFF
--- a/settlement-service/src/main/java/com/happymapleday/settlement/SettlementApplication.java
+++ b/settlement-service/src/main/java/com/happymapleday/settlement/SettlementApplication.java
@@ -1,15 +1,13 @@
 package com.happymapleday.settlement;
 
-import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = "com.happymapleday")
 @EnableFeignClients(basePackages = "com.happymapleday")
-@EnableBatchProcessing
 @EnableScheduling
 @EnableCaching
 public class SettlementApplication {


### PR DESCRIPTION
# 문제 상황
## Settlement-Service API 404 에러

### 상황
프론트엔드에서 settlement-service의 API `(/api/settlement/user/{userId}/week/{weekStartDate})`를 호출할 때 404 에러 발생.

### 문제 파악
서비스는 정상 실행 중이지만 서버 로그에 컨트롤러 매핑 정보가 출력되지 않음.

```
// 문제가 있던 코드
@SpringBootApplication // scanBasePackage 속성 부재
@EnableFeignClients(basePackages = "com.happymapleday")
@EnableBatchProcessing  // Spring Boot 3.x에서 deprecated 되었음
@EnableScheduling
@EnableCaching
public class SettlementApplication {
    public static void main(String[] args) {
        SpringApplication.run(SettlementApplication.class, args);
    }
}
```
- 다른 서비스들은 `@EnableBatchProcessing`을 사용하지 않아 문제 없었음


### 해결 방안
```
@SpringBootApplication(scanBasePackages = "com.happymapleday") // scanBasePackages  추가
@EnableFeignClients(basePackages = "com.happymapleday")
// @EnableBatchProcessing 제거
@EnableScheduling
@EnableCaching
public class SettlementApplication {
    public static void main(String[] args) {
        SpringApplication.run(SettlementApplication.class, args);
    }
}
```

**merge 후 재배포하여 test 요망**
